### PR TITLE
Add Series Taxonomy

### DIFF
--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -9,6 +9,7 @@ next: /tutorials/github-pages-blog
 prev: /tutorials/automated-deployments
 title: Creating a New Theme
 weight: 10
+series: Hugo 101
 ---
 
 

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -14,6 +14,7 @@ categories = [
     "golang",
 ]
 menu = "main"
+series = "Hugo 101"
 +++
 
 Hugo uses the excellent [Go][] [html/template][gohtmltemplate] library for

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -13,6 +13,7 @@ categories = [
     "golang",
 ]
 menu = "main"
+series = "Hugo 101"
 +++
 
 ## Step 1. Install Hugo

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -7,6 +7,7 @@ menu:
 prev: /tutorials/mathjax
 title: Migrate to Hugo from Jekyll
 weight: 10
+series: Hugo 101
 ---
 
 ## Move static content to `static`


### PR DESCRIPTION
Closes #18 

@digitalcraftsman  this is the humble first PR of the effort to revamp the HugoBasicExample. Also note that the actual content of these markdown files will be updated in a future PR. 

I have added the taxonomy only in the front matter of the content files for themes that need it. From what I've seen there are a few. I have not configured this taxonomy in `config.toml` of this repo so that it is not enabled in theme demos that already use the HugoBasicExample.