### PR TITLE
Disable French

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,7 @@ canonifyurls = true
 paginate = 3
 languageCode = "en"
 DefaultContentLanguage = "en"
+disableLanguages = ["fr"]
 
 [languages.en]
 languageName = "English"


### PR DESCRIPTION
Commit 93a7b4c had the side effect of causing existing theme demos that rely on the HugoBasicExample to display the French language posts.

So with this PR the French translation of the posts is disabled by default, to keep things for existing demos as before.

**NOTE**
When we are done with overhauling the HugoBasicExample we will need to add documentation in its README. 

For example in this case we will need to state that authors who wish to have a multilingual theme demo will need to remove `disableLanguages = ["fr"]` from the exampleSite config.

cc: @digitalcraftsman 