### PR TITLE
Revert "Add Series Taxonomy (#19)"

### DIFF
--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -9,7 +9,6 @@ next: /tutorials/github-pages-blog
 prev: /tutorials/automated-deployments
 title: Creating a New Theme
 weight: 10
-series: Hugo 101
 ---
 
 

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -14,7 +14,6 @@ categories = [
     "golang",
 ]
 menu = "main"
-series = "Hugo 101"
 +++
 
 Hugo uses the excellent [Go][] [html/template][gohtmltemplate] library for

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -13,7 +13,6 @@ categories = [
     "golang",
 ]
 menu = "main"
-series = "Hugo 101"
 +++
 
 ## Step 1. Install Hugo

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -7,7 +7,6 @@ menu:
 prev: /tutorials/mathjax
 title: Migrate to Hugo from Jekyll
 weight: 10
-series: Hugo 101
 ---
 
 ## Move static content to `static`


### PR DESCRIPTION
This reverts commit 4e47e94a69eb67a37f0dd55a2b4eaad05bb8ffe3.

A [great number](https://app.netlify.com/sites/hugothemes/deploys/5c6936d1dddaef000819a6e8) of theme demos on the website broke because of this commit due to the following:

- Series is on the predefined frontmatter variable lists due to its use in the internal opengraph template.
- Series is predefined as an array whereas I entered it as a string.
- Also series needs to be defined as a Taxonomy in the config of an exampleSite. Since the config is inherited by theme authors if they have not defined the series taxonomy then their demo will again break.

**NOTE**
I will be more rigorous with testing before sending more PRs.

cc: @digitalcraftsman 