### PR TITLE
Re-add Series Taxonomy with 2nd config

### DIFF
--- a/configTaxo.toml
+++ b/configTaxo.toml
@@ -1,0 +1,2 @@
+[taxonomies]
+series = "series"

--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -9,6 +9,8 @@ next: /tutorials/github-pages-blog
 prev: /tutorials/automated-deployments
 title: Creating a New Theme
 weight: 10
+series:
+- Hugo 101
 ---
 
 

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -14,6 +14,7 @@ categories = [
     "golang",
 ]
 menu = "main"
+series = ["Hugo 101"]
 +++
 
 Hugo uses the excellent [Go][] [html/template][gohtmltemplate] library for

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -13,6 +13,7 @@ categories = [
     "golang",
 ]
 menu = "main"
+series = ["Hugo 101"]
 +++
 
 ## Step 1. Install Hugo

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -7,6 +7,8 @@ menu:
 prev: /tutorials/mathjax
 title: Migrate to Hugo from Jekyll
 weight: 10
+series:
+- Hugo 101
 ---
 
 ## Move static content to `static`


### PR DESCRIPTION
With this PR I am re-adding the series taxonomy but this time I am including a second config file that contains the taxonomies configuration.

The previous commit broke some 35 theme demos on the Hugo website because the Series taxonomy is used in the internal OpenGraph template. Most of the theme demos that broke are using their own `exampleSite/config.toml` and since a Series taxonomy was not configured in their configs Hugo threw all these demo breaking errors.

This PR solves the previous problem and to work it needs to be merged in tandem with https://github.com/gohugoio/hugoThemes/pull/570 that will make the Themes Site Build Script use the second config that is included in this PR.

Also a benefit of this PR is that more taxonomies can be configured for theme demos based on the overall needs.

cc: @digitalcraftsman 