### PR TITLE
Move menu configuration in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,3 +17,11 @@ title = "Hugo Themes"
 languageName = "Français"
 weight = 2
 title = "Thèmes Hugo"
+
+[menu]
+
+  [[menu.main]]
+    identifier = "tutorials"
+    name = "Tutorials"
+    url = "/post/"
+    weight = 5

--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -2,11 +2,6 @@
 author: "Michael Henderson"
 date: 2014-09-28
 linktitle: Creating a New Theme
-menu:
-  main:
-    parent: tutorials
-next: /tutorials/github-pages-blog
-prev: /tutorials/automated-deployments
 title: Creating a New Theme
 weight: 10
 series:

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -13,7 +13,6 @@ categories = [
     "Development",
     "golang",
 ]
-menu = "main"
 series = ["Hugo 101"]
 +++
 

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -12,7 +12,6 @@ categories = [
     "Development",
     "golang",
 ]
-menu = "main"
 series = ["Hugo 101"]
 +++
 

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -1,10 +1,6 @@
 ---
 date: 2014-03-10
 linktitle: Migrating from Jekyll
-menu:
-  main:
-    parent: tutorials
-prev: /tutorials/mathjax
 title: Migrate to Hugo from Jekyll
 weight: 10
 series:


### PR DESCRIPTION
Fixes #17 

Also the menu from now on will have only 2 items:

- About
- Tutorials

No need to have all the individual post links. The plethora of links made the layout of several themes look bad.

Also note that when the actual content of this repo is updated to something more neutral the Menu items will also be updated as part of that Pull Request.

cc: @digitalcraftsman 