### PR TITLE
Add more Taxonomies configuration

### DIFF
--- a/configTaxo.toml
+++ b/configTaxo.toml
@@ -1,2 +1,4 @@
 [taxonomies]
+category = "categories"
+tag = "tags"
 series = "series"


### PR DESCRIPTION
This PR adds the default Hugo taxonomies configuration in the second config of the HugoBasicExample.

This PR will fix a number of theme demos that currently require the default Hugo taxonomies.

For example the [Plain Blog](https://themes.gohugo.io/plain-blog/) theme demo will generate once again after this PR is merged.

Also for the changes of this PR to be reflected on the Themes Site, once again a manual Netlify deploy needs to be triggered.

cc: @digitalcraftsman 