### PR TITLE
Move About menu item to config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,5 +23,11 @@ title = "Thèmes Hugo"
   [[menu.main]]
     identifier = "tutorials"
     name = "Tutorials"
-    url = "/post/"
+    url = "post/"
     weight = 5
+
+  [[menu.main]]
+    identifier = "about"
+    name = "About"
+    url = "about/"
+    weight = 10

--- a/content/about.md
+++ b/content/about.md
@@ -1,7 +1,7 @@
 +++
-title = "About Hugo"
+title = "About"
 date = "2014-04-09"
-menu = "main"
+aliases = ["about-us","about-hugo"]
 +++
 
 Hugo is the **world’s fastest framework for building websites**. It is written in Go.


### PR DESCRIPTION
This should fix the About menu item duplication in various theme demos like in [this one](https://themes.gohugo.io//theme/hermit/)

cc: @digitalcraftsman 