### PR TITLE
Disable French

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,7 @@
 baseurl = "https://gohugo.io/"
 title = "Hugo Themes"
 author = "Steve Francia"
-copyright = "Copyright © 2008–2018, Steve Francia and the Hugo Authors; all rights reserved."
-canonifyurls = true
+copyright = "Copyright © 2008–2019, Steve Francia and the Hugo Authors; all rights reserved."
 paginate = 3
 languageCode = "en"
 DefaultContentLanguage = "en"

--- a/configTaxo.toml
+++ b/configTaxo.toml
@@ -1,3 +1,17 @@
+languageCode = "en"
+DefaultContentLanguage = "en"
+disableLanguages = ["fr"]
+
+[languages.en]
+languageName = "English"
+weight = 1
+title = "Hugo Themes"
+
+[languages.fr]
+languageName = "Français"
+weight = 2
+title = "Thèmes Hugo"
+
 [taxonomies]
 category = "categories"
 tag = "tags"


### PR DESCRIPTION
After merging commit 93a7b4c every demo on the website started displaying both the English and the French languages posts despite entering `disableLanguages = "fr"` in `config.toml`

This PR addresses this issue by entering the Multilingual configuration and disabling French in the second config that is executed in the Build Script after a theme demo's first config.

If a theme has an exampleSite then the first config is inherited from it.
If a theme demo relies on the HugoBasicExample its config is created by the Build Script using data from `theme.toml` and as a result the first config of this repo has no effect.

The second config that is taken into account after whatever the first one is the one in which Language configuration and disabling French needs to take place.

Note that these settings are already present in the first config, so that if a user clones this repo locally then the language configuration is present without having to rely on the second config.

Also I have made some other minor edits in the first config of the repo, like updating the copyright year and removing canonifyURLs (since this is done by the Build Script it's not really needed)

cc: @digitalcraftsman 
