### PR TITLE
Add Posts Type

### DIFF
--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -2,6 +2,7 @@
 author: "Michael Henderson"
 date: 2014-09-28
 linktitle: Creating a New Theme
+type: posts
 title: Creating a New Theme
 weight: 10
 series:

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -1,6 +1,7 @@
 +++
 title = "(Hu)go Template Primer"
 description = ""
+type = "posts"
 tags = [
     "go",
     "golang",

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -1,6 +1,7 @@
 +++
 title = "Getting Started with Hugo"
 description = ""
+type = "posts"
 tags = [
     "go",
     "golang",

--- a/content/post/migrate-from-jekyll.fr.md
+++ b/content/post/migrate-from-jekyll.fr.md
@@ -9,7 +9,7 @@ featuredpath = ""
 linktitle = ""
 slug = "Migrer vers Hugo depuis Jekyll"
 title = "Migrer vers Hugo depuis Jekyll"
-type = "post"
+type = "posts"
 
 +++
 

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -2,6 +2,7 @@
 date: 2014-03-10
 linktitle: Migrating from Jekyll
 title: Migrate to Hugo from Jekyll
+type: posts
 weight: 10
 series:
 - Hugo 101


### PR DESCRIPTION
This PR adds a `type = "posts"` for themes that need it. 

Most notably [Hyde Hyde](https://themes.gohugo.io/theme/hyde-hyde/) that currently has its index page empty will have it populated with posts once again.

If more themes need different content types I will see whether it is possible to turn `type` into an array to add more of these.

cc: @digitalcraftsman 