### PR TITLE
Update Content

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,7 +1,9 @@
 +++
 title = "About"
 date = "2014-04-09"
-aliases = ["about-us","about-hugo"]
+aliases = ["about-us","about-hugo","contact"]
+[ author ]
+  name = "Hugo Authors"
 +++
 
 Hugo is the **world’s fastest framework for building websites**. It is written in Go.

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,3 +1,6 @@
 +++
 aliases = ["posts","articles","blog","showcase"]
+title = "Posts"
+[ author ]
+  name = "Hugo Authors"
 +++

--- a/content/post/creating-a-new-theme.fr.md
+++ b/content/post/creating-a-new-theme.fr.md
@@ -1,5 +1,4 @@
 +++
-author = "Auteur du thème"
 categories = ["Hugo"]
 date = "2014-09-28"
 description = "Apprenez comment créer un thème Hugo"
@@ -10,7 +9,6 @@ linktitle = ""
 title = "Création d'un nouveau thème"
 slug = "Creation d'un nouveau theme"
 type = "post"
-
 +++
 
 ## Introduction

--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -1,8 +1,11 @@
 ---
-author: "Michael Henderson"
+author:
+  name: "Michael Henderson"
 date: 2014-09-28
 linktitle: Creating a New Theme
-type: posts
+type:
+- post 
+- posts
 title: Creating a New Theme
 weight: 10
 series:

--- a/content/post/goisforlovers.fr.md
+++ b/content/post/goisforlovers.fr.md
@@ -1,5 +1,4 @@
 +++
-author = "Auteur inconnu"
 categories = ["Go"]
 date = "2014-04-02"
 description = ""
@@ -9,8 +8,9 @@ featuredpath = "date"
 linktitle = ""
 slug = "Introduction aux modeles Hugo"
 title = "Introduction aux modèles (Hu)go"
-type = "post"
-
+type = ["posts","post"]
+[ author ]
+  name = "Michael Henderson"
 +++
 
 Hugo utilise l'excellente librairie [go][] [html/template][gohtmltemplate] pour

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -1,7 +1,7 @@
 +++
 title = "(Hu)go Template Primer"
 description = ""
-type = "posts"
+type = ["posts","post"]
 tags = [
     "go",
     "golang",
@@ -15,6 +15,8 @@ categories = [
     "golang",
 ]
 series = ["Hugo 101"]
+[ author ]
+  name = "Hugo Authors"
 +++
 
 Hugo uses the excellent [Go][] [html/template][gohtmltemplate] library for

--- a/content/post/hugoisforlovers.fr.md
+++ b/content/post/hugoisforlovers.fr.md
@@ -1,5 +1,4 @@
 +++
-author = "Auteur Hugo"
 categories = ["Hugo"]
 date = "2014-04-02"
 description = ""
@@ -10,7 +9,8 @@ linktitle = ""
 slug = "Debuter avec Hugo"
 title = "Débuter avec Hugo"
 type = "post"
-
+[ author ]
+  name = "Hugo Authors"
 +++
 
 ## Étape 1. Installer Hugo

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -1,7 +1,7 @@
 +++
 title = "Getting Started with Hugo"
 description = ""
-type = "posts"
+type = ["posts","post"]
 tags = [
     "go",
     "golang",
@@ -14,6 +14,8 @@ categories = [
     "golang",
 ]
 series = ["Hugo 101"]
+[ author ]
+  name = "Hugo Authors"
 +++
 
 ## Step 1. Install Hugo

--- a/content/post/migrate-from-jekyll.fr.md
+++ b/content/post/migrate-from-jekyll.fr.md
@@ -1,5 +1,4 @@
 +++
-author = "Auteur de migration"
 categories = ["Hugo", "Jekyll"]
 date = "2014-03-10"
 description = ""
@@ -9,8 +8,9 @@ featuredpath = ""
 linktitle = ""
 slug = "Migrer vers Hugo depuis Jekyll"
 title = "Migrer vers Hugo depuis Jekyll"
-type = "posts"
-
+type = ["posts","post"]
+[ author ]
+  name = "Hugo Authors"
 +++
 
 ## Déplacez le contenu statique vers `static`

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -1,8 +1,12 @@
 ---
+author:
+  name: "Hugo Authors"
 date: 2014-03-10
 linktitle: Migrating from Jekyll
 title: Migrate to Hugo from Jekyll
-type: posts
+type:
+- post 
+- posts
 weight: 10
 series:
 - Hugo 101


### PR DESCRIPTION
This PR contains the following:

- Continuing from #31 content `type` is now an array because some themes use `post` (e.g. [CleanWhite](https://themes.gohugo.io/hugo-theme-cleanwhite/ ))while others `posts` (e.g. [Hyde Hyde](https://themes.gohugo.io/hyde-hyde/) to populate their list pages.

- Added `title` parameter in `content/post/_index.md`. This fixes the demo of [Midnight](https://themes.gohugo.io/midnight/)

-  The `author` parameter is now an [Inline Table](https://github.com/toml-lang/toml#inline-table). Fixes the errors that break the demos of [Hugo MDL](https://themes.gohugo.io/hugo-mdl/) and [Hugo Dream Plus](https://themes.gohugo.io/hugo-dream-plus/)

- Updated the `author.name` parameter to `Hugo Authors` since my name is not Michael Henderson.

cc: @digitalcraftsman 