### PR TITLE
Revert author parameter back to a string

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -2,8 +2,7 @@
 title = "About"
 date = "2014-04-09"
 aliases = ["about-us","about-hugo","contact"]
-[ author ]
-  name = "Hugo Authors"
+author = "Hugo Authors"
 +++
 
 Hugo is the **world’s fastest framework for building websites**. It is written in Go.

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,6 +1,5 @@
 +++
 aliases = ["posts","articles","blog","showcase"]
 title = "Posts"
-[ author ]
-  name = "Hugo Authors"
+author = "Hugo Authors"
 +++

--- a/content/post/creating-a-new-theme.fr.md
+++ b/content/post/creating-a-new-theme.fr.md
@@ -9,6 +9,7 @@ linktitle = ""
 title = "Création d'un nouveau thème"
 slug = "Creation d'un nouveau theme"
 type = "post"
+author = "Hugo Auteurs"
 +++
 
 ## Introduction

--- a/content/post/creating-a-new-theme.md
+++ b/content/post/creating-a-new-theme.md
@@ -1,6 +1,5 @@
 ---
-author:
-  name: "Michael Henderson"
+author: "Hugo Authors"
 date: 2014-09-28
 linktitle: Creating a New Theme
 type:

--- a/content/post/goisforlovers.fr.md
+++ b/content/post/goisforlovers.fr.md
@@ -9,8 +9,7 @@ linktitle = ""
 slug = "Introduction aux modeles Hugo"
 title = "Introduction aux modèles (Hu)go"
 type = ["posts","post"]
-[ author ]
-  name = "Michael Henderson"
+author = "Hugo Auteurs"
 +++
 
 Hugo utilise l'excellente librairie [go][] [html/template][gohtmltemplate] pour

--- a/content/post/goisforlovers.md
+++ b/content/post/goisforlovers.md
@@ -15,8 +15,7 @@ categories = [
     "golang",
 ]
 series = ["Hugo 101"]
-[ author ]
-  name = "Hugo Authors"
+author = "Hugo Authors"
 +++
 
 Hugo uses the excellent [Go][] [html/template][gohtmltemplate] library for

--- a/content/post/hugoisforlovers.fr.md
+++ b/content/post/hugoisforlovers.fr.md
@@ -9,8 +9,7 @@ linktitle = ""
 slug = "Debuter avec Hugo"
 title = "Débuter avec Hugo"
 type = "post"
-[ author ]
-  name = "Hugo Authors"
+author = "Hugo Auteurs"
 +++
 
 ## Étape 1. Installer Hugo

--- a/content/post/hugoisforlovers.md
+++ b/content/post/hugoisforlovers.md
@@ -14,8 +14,7 @@ categories = [
     "golang",
 ]
 series = ["Hugo 101"]
-[ author ]
-  name = "Hugo Authors"
+author = "Hugo Authors"
 +++
 
 ## Step 1. Install Hugo

--- a/content/post/migrate-from-jekyll.fr.md
+++ b/content/post/migrate-from-jekyll.fr.md
@@ -9,8 +9,7 @@ linktitle = ""
 slug = "Migrer vers Hugo depuis Jekyll"
 title = "Migrer vers Hugo depuis Jekyll"
 type = ["posts","post"]
-[ author ]
-  name = "Hugo Authors"
+author = "Hugo Auteurs"
 +++
 
 ## Déplacez le contenu statique vers `static`

--- a/content/post/migrate-from-jekyll.md
+++ b/content/post/migrate-from-jekyll.md
@@ -1,6 +1,5 @@
 ---
-author:
-  name: "Hugo Authors"
+author: "Hugo Authors"
 date: 2014-03-10
 linktitle: Migrating from Jekyll
 title: Migrate to Hugo from Jekyll


### PR DESCRIPTION
This reverts the author front matter parameter back to a string in order to fix the 12 theme demos that broke with #33 

The demos that were supposed to be fixed in that PR were whiteListed with https://github.com/gohugoio/hugoThemes/pull/586

cc: @digitalcraftsman 