### PR TITLE
Add timeout

### DIFF
--- a/configTaxo.toml
+++ b/configTaxo.toml
@@ -1,3 +1,4 @@
+timeout = 30000
 enableInlineShortcodes = true
 footnoteReturnLinkContents = "^"
 


### PR DESCRIPTION
In the  latest deploy of Hugo Themes a couple of demos broke with the following ERROR:
```
Error building site: "/opt/build/repo/_script/hugoThemeSite/exampleSite/content/post/rich-content.md:1:1": timed out initializing value. This is most likely a circular loop in a shortcode
```

So to counter the above I added a `timeout` parameter in the second config that is enforced in all theme demos.
