### PR TITLE
Fix author to be a map instead of scalar in config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 baseURL = "https://gohugo.io"
 title = "Hugo Themes"
-author = "Steve Francia"
 copyright = "Copyright © 2008–2019, Steve Francia and the Hugo Authors; all rights reserved."
 paginate = 3
 languageCode = "en"
@@ -9,6 +8,10 @@ enableInlineShortcodes = true
 # prevent build failures when using Hugo's Instagram shortcode due to deprecated Instagram API.
 # See https://github.com/gohugoio/hugo/issues/7228#issuecomment-714490456
 ignoreErrors = ["error-remote-getjson"]
+
+[author]
+  name = "Steve Francia"
+  email = "steve.francia@example.com"
 
 [menu]
 


### PR DESCRIPTION
Since .Site.Author expects the author variable in config.toml to be a map not a scalar, change author to be a map (see https://github.com/gohugoio/hugoBasicExample/issues/69)

Closes https://github.com/gohugoio/hugoBasicExample/issues/69

Note that I used the actual email in @spf13's public profile (as he is the author who created the original version). If preferred this could be replaced by something like ``email = "undisclosed@example.com"``
