### PR TITLE
Un-nest the <kbd> example

### DIFF
--- a/content/post/markdown-syntax.md
+++ b/content/post/markdown-syntax.md
@@ -143,6 +143,6 @@ H<sub>2</sub>O
 
 X<sup>n</sup> + Y<sup>n</sup> = Z<sup>n</sup>
 
-Press <kbd><kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>Delete</kbd></kbd> to end the session.
+Press <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>Delete</kbd> to end the session.
 
 Most <mark>salamanders</mark> are nocturnal, and hunt for insects, worms, and other small creatures.


### PR DESCRIPTION
Nesting `<kbd>` within `<kbd>` would be very unusual.  The point of this page is to demonstrate commonly used styles.
In some cases the nesting causes the individual "keys" to lose their distinction.