### PR TITLE
 Update twitter_simple shortcode parameters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 /public
 /themes
 .DS_Store
+
+# Build artifacts
+.hugo_build.lock

--- a/content/post/rich-content.md
+++ b/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< twitter_simple user="designreviewed" id="1085870671291310081" >}}
 
 <br>
 


### PR DESCRIPTION
The ID-only syntax for twitter_simple is being deprecated, and it will
soon require "user" and "id" parameters.

Fixes #81.