### PR TITLE
fix twitter shortcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 /public
 /themes
 .DS_Store
+.hugo_build.lock

--- a/content/post/rich-content.md
+++ b/content/post/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< twitter_simple 1085870671291310081 >}}
+{{< twitter user="SanDiegoZoo" id="1453110110599868418" >}}
 
 <br>
 


### PR DESCRIPTION
As of hugo v0.123.0, the basic example site fails with an error due to improper use of `twitter` shortcode.

```
& hugo
Start building sites … 
hugo v0.123.0-3c8a4713908e48e6523f058ca126710397aa4ed5+extended linux/amd64 BuildDate=2024-02-19T16:32:38Z VendorInfo=gohugoio
(...)
ERROR The "twitter_simple" shortcode requires two named parameters: user and id. See "/home/andreas/hugoBasicExample/content/post/rich-content.md:26:1"
Total in 59 ms
Error: error building site: logged 1 error(s)
```

This PR fixes this error.